### PR TITLE
feat: 現在地に戻るボタンの実装 (#8)

### DIFF
--- a/app/screens/MapScreen.tsx
+++ b/app/screens/MapScreen.tsx
@@ -1,10 +1,13 @@
-import React, { useState, useEffect } from 'react';
-import { StyleSheet, View, Alert } from 'react-native';
+import React, { useState, useEffect, useRef } from 'react';
+import { StyleSheet, View, Alert, TouchableOpacity } from 'react-native';
 import MapView, { PROVIDER_GOOGLE, Region } from 'react-native-maps';
 import * as Location from 'expo-location';
+import { MaterialIcons } from '@expo/vector-icons';
 
 export default function MapScreen() {
   const [region, setRegion] = useState<Region | null>(null);
+  const [currentLocation, setCurrentLocation] = useState<Location.LocationObject | null>(null);
+  const mapRef = useRef<MapView>(null);
 
   useEffect(() => {
     (async () => {
@@ -15,6 +18,7 @@ export default function MapScreen() {
       }
 
       let location = await Location.getCurrentPositionAsync({});
+      setCurrentLocation(location);
       setRegion({
         latitude: location.coords.latitude,
         longitude: location.coords.longitude,
@@ -24,9 +28,37 @@ export default function MapScreen() {
     })();
   }, []);
 
+  const handleCenterLocation = () => {
+    if (currentLocation && mapRef.current) {
+      mapRef.current.animateToRegion({
+        latitude: currentLocation.coords.latitude,
+        longitude: currentLocation.coords.longitude,
+        latitudeDelta: 0.01,
+        longitudeDelta: 0.01,
+      }, 1000);
+    } else {
+      // If no location yet, try fetching again or alert
+      (async () => {
+        try {
+          let location = await Location.getCurrentPositionAsync({});
+          setCurrentLocation(location);
+          mapRef.current?.animateToRegion({
+            latitude: location.coords.latitude,
+            longitude: location.coords.longitude,
+            latitudeDelta: 0.01,
+            longitudeDelta: 0.01,
+          }, 1000);
+        } catch (e) {
+          Alert.alert('Could not get current location');
+        }
+      })();
+    }
+  };
+
   return (
     <View style={styles.container}>
       <MapView
+        ref={mapRef}
         style={styles.map}
         provider={PROVIDER_GOOGLE}
         region={region || {
@@ -37,6 +69,13 @@ export default function MapScreen() {
         }}
         showsUserLocation={true}
       />
+      <TouchableOpacity
+        style={styles.fab}
+        onPress={handleCenterLocation}
+        activeOpacity={0.7}
+      >
+        <MaterialIcons name="my-location" size={24} color="#007AFF" />
+      </TouchableOpacity>
     </View>
   );
 }
@@ -48,5 +87,24 @@ const styles = StyleSheet.create({
   map: {
     width: '100%',
     height: '100%',
+  },
+  fab: {
+    position: 'absolute',
+    right: 16,
+    bottom: 16, // Adjust if there's a tab bar, usually tab bar height is around 50-80
+    backgroundColor: 'white',
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    justifyContent: 'center',
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+    elevation: 5,
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kimamap_demo",
       "version": "1.0.0",
       "dependencies": {
+        "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-navigation/bottom-tabs": "^7.8.5",
         "@react-navigation/native": "^7.1.20",
@@ -2242,6 +2243,17 @@
       "resolved": "https://registry.npmjs.org/@expo/sudo-prompt/-/sudo-prompt-9.3.2.tgz",
       "integrity": "sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==",
       "license": "MIT"
+    },
+    "node_modules/@expo/vector-icons": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.0.3.tgz",
+      "integrity": "sha512-SBUyYKphmlfUBqxSfDdJ3jAdEVSALS2VUPOUyqn48oZmb2TL/O7t7/PQm5v4NQujYEPLPMTLn9KVw6H7twwbTA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo-font": ">=14.0.4",
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/@expo/ws-tunnel": {
       "version": "1.0.6",
@@ -4861,6 +4873,20 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-font": {
+      "version": "14.0.9",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.9.tgz",
+      "integrity": "sha512-xCoQbR/36qqB6tew/LQ6GWICpaBmHLhg/Loix5Rku/0ZtNaXMJv08M9o1AcrdiGTn/Xf/BnLu6DgS45cWQEHZg==",
+      "license": "MIT",
+      "dependencies": {
+        "fontfaceobserver": "^2.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-linking": {
       "version": "8.0.9",
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.9.tgz",
@@ -5189,17 +5215,6 @@
         }
       }
     },
-    "node_modules/expo/node_modules/@expo/vector-icons": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.0.3.tgz",
-      "integrity": "sha512-SBUyYKphmlfUBqxSfDdJ3jAdEVSALS2VUPOUyqn48oZmb2TL/O7t7/PQm5v4NQujYEPLPMTLn9KVw6H7twwbTA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo-font": ">=14.0.4",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -5349,20 +5364,6 @@
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo/node_modules/expo-font": {
-      "version": "14.0.9",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.9.tgz",
-      "integrity": "sha512-xCoQbR/36qqB6tew/LQ6GWICpaBmHLhg/Loix5Rku/0ZtNaXMJv08M9o1AcrdiGTn/Xf/BnLu6DgS45cWQEHZg==",
-      "license": "MIT",
-      "dependencies": {
-        "fontfaceobserver": "^2.1.0"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
         "react-native": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/bottom-tabs": "^7.8.5",
     "@react-navigation/native": "^7.1.20",


### PR DESCRIPTION
## 概要
地図画面（MapScreen）に、現在地へスムーズに戻るためのフローティングアクションボタン（FAB）を追加しました。

## 変更点
- **MapScreen.tsx**:
  -  を使用して  のインスタンスを取得
  -  のターゲットアイコンを使用したFABを右下に配置
  - ボタン押下時に  で現在地へ移動するロジックを実装
- **package.json**:
  - アイコン表示のために  を追加

## 動作確認
- [x] 地図をスクロールして現在地から離れる
- [x] 右下のボタンをタップ
- [x] 地図が現在地中心にアニメーション移動することを確認

Closes #8