### PR TITLE
fix: ログイン時にアカウント選択画面を強制表示する (Issue #37)

### DIFF
--- a/app/contexts/AuthContext.tsx
+++ b/app/contexts/AuthContext.tsx
@@ -53,6 +53,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         options: {
           redirectTo: redirectUrl,
           skipBrowserRedirect: true,
+          queryParams: {
+            prompt: 'select_account',
+          },
         },
       });
 


### PR DESCRIPTION
## 修正内容
Supabaseの `signInWithOAuth` メソッドに `queryParams: { prompt: 'select_account' }` を追加しました。
これにより、ログイン試行時にブラウザで常にGoogleアカウント選択画面が表示されるようになります。

Closes #37