### PR TITLE
feat(#35): Google Mapsアプリでのナビ起動機能

### DIFF
--- a/app/navigation/types.ts
+++ b/app/navigation/types.ts
@@ -4,7 +4,7 @@ import { Plan } from '../services/api';
 export type MapStackParamList = {
   MapScreen: undefined;
   Search: undefined;
-  SearchResult: { plan: Plan };
+  SearchResult: { plan: Plan; transportation: 'walk' | 'bicycle' | 'car' };
 };
 
 export type MainTabParamList = {

--- a/app/screens/SearchScreen.tsx
+++ b/app/screens/SearchScreen.tsx
@@ -111,7 +111,7 @@ export default function SearchScreen() {
               // Then navigate to the result screen.
               // Since code execution continues after goBack, this will queue the navigation
               // to happen immediately after the modal dismissal starts.
-              navigation.navigate('SearchResult', { plan: response.plan });
+              navigation.navigate('SearchResult', { plan: response.plan, transportation });
             }
           }
         ]


### PR DESCRIPTION
## 概要
「案内を開始」ボタンをタップすると、Google Mapsアプリでルートナビゲーションを開始できます。

## 変更内容
- Linking APIを使用してGoogle Maps URLを構築
- 出発地・目的地・経由地点を含むルートを開く
- 移動手段(walk/bicycle/car)を動的にマッピング

## テスト結果
- 実機で動作確認済み

Closes #35