### PR TITLE
Place ID対応でGoogle Mapsの地点名表示を改善

### DIFF
--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -24,6 +24,7 @@ export interface Spot {
   location: Location;
   stayDuration: number;
   address?: string;
+  placeId?: string;
 }
 
 export interface Plan {

--- a/server/src/agent/state.ts
+++ b/server/src/agent/state.ts
@@ -12,6 +12,7 @@ export interface Spot {
     lng: number;
   };
   address: string;
+  placeId: string;
 }
 
 // Define the structure of the Plan


### PR DESCRIPTION
 - 概要
      - 「案内を開始」でGoogle Mapsを開いた際に、経由地/目的地が「指定した地点」表示になりやすい問題を改善しました。Place ID を付与して Google Maps URL に渡すことで、地点名付きで表示されやすくします。
  - 変更点
      - サーバー: プラン生成で各スポットの placeId (ChIJ...) を出力/補完（groundingMetadata から補完）
      - クライアント: Google Maps起動URLで destination_place_id / waypoint_place_ids を利用、名前/住所も優先して渡す
      - 型: Spot に placeId を追加
  - 動作確認
      - 検索→プラン生成→検索結果の「案内を開始」で、Google Maps上の地点が名前付きで表示されることを確認